### PR TITLE
Export Updated

### DIFF
--- a/js/Export.js
+++ b/js/Export.js
@@ -389,13 +389,14 @@ define([
                             var bbox = (this.geometry.xmin + ", " + this.geometry.ymin + ", " + this.geometry.xmax + ", " + this.geometry.ymax).toString();
                             var width = (this.geometry.xmax - this.geometry.xmin);
                             var height = (this.geometry.ymax - this.geometry.ymin);
-
+                            var bboxSR = this.geometry.spatialReference;
 
                         } else
                         {
                             var bbox = (this.map.extent.xmin + ", " + this.map.extent.ymin + ", " + this.map.extent.xmax + ", " + this.map.extent.ymax).toString();
                             var width = (this.map.extent.xmax - this.map.extent.xmin);
                             var height = (this.map.extent.ymax - this.map.extent.ymin);
+                             var bboxSR = this.map.spatialReference;
                         }
 
                         var pixelsize = parseFloat(registry.byId("pixelSize").get("value"));
@@ -450,6 +451,7 @@ define([
                                 content: {
                                     f: "json",
                                     bbox: bbox,
+                                    bboxSR:JSON.stringify(bboxSR),
                                     size: size,
                                     compression: compression,
                                     format: format,


### PR DESCRIPTION
Bug - Bounding box spatial reference was not appended to export image call when the image is saved to disk.